### PR TITLE
✨ Support for trustup-pro-premium plan

### DIFF
--- a/src/Contracts/Models/Query/PlanQueryContract.php
+++ b/src/Contracts/Models/Query/PlanQueryContract.php
@@ -38,4 +38,12 @@ interface PlanQueryContract extends QueryContract
      * @return PlanQueryContract
      */
     public function whereApp(AppContract $app): PlanQueryContract;
+
+    /**
+     * Limiting plans to those matching given app or global plans
+     * 
+     * @param AppContract $app
+     * @return PlanQueryContract
+     */
+    public function whereAppOrGlobal(AppContract $app): PlanQueryContract;
 }

--- a/src/Models/AccountChargebee.php
+++ b/src/Models/AccountChargebee.php
@@ -467,7 +467,7 @@ class AccountChargebee extends AdminModel implements AccountChargebeeContract
 
         $plan = app()->make(PlanQueryContract::class)
             ->whereName($subscription->getPlan()->getId())
-            ->whereApp($this->getAccount()->getApp())
+            ->whereAppOrGlobal($this->getAccount()->getApp())
             ->first();
 
         return $this->setPlan($plan);

--- a/src/Models/Query/PlanQuery.php
+++ b/src/Models/Query/PlanQuery.php
@@ -76,4 +76,23 @@ class PlanQuery extends AbstractQuery implements PlanQueryContract
 
         return $this;
     }
+
+    /**
+     * Limiting plans to those matching given app or global plans (app_id = null).
+     * 
+     * @param AppContract $app
+     * @return PlanQueryContract
+     */
+    public function whereAppOrGlobal(AppContract $app): PlanQueryContract
+    {
+        $this->getQuery()->where(function(Builder $builder) use ($app) {
+            $builder->whereHas('app', function(Builder $builder) use ($app) {
+                $query = app()->make(AppQueryContract::class);
+                $query->setQuery($builder)
+                    ->whereKeyIs($app->getKey());
+            })->orWhereNull('app_id');
+        });
+
+        return $this;
+    }
 }

--- a/src/Models/Services/Account/Contracts/AccountSubscriberContract.php
+++ b/src/Models/Services/Account/Contracts/AccountSubscriberContract.php
@@ -11,6 +11,17 @@ use Deegitalbe\TrustupProAdminCommon\Contracts\Models\UserContract;
 
 interface AccountSubscriberContract extends ContextualContract
 {
+
+    /**
+     * Suscribe the account to the existing Pack subscription based on the ID given.
+     * 
+     * @param AccountContract $account
+     * @param UserContract $user Used as callback for customer if professional not being one already.
+     * @param string $packSucriptionId The ID of the subcription used for the pack.
+     * @return AccountContract
+     */
+    public function usePackSubscription(AccountContract $account, UserContract $user, string $packSubscriptionId): bool;
+
     /**
      * Subscribing given account.
      * 


### PR DESCRIPTION
The trustup-pro-premium and trustup-pro-premium-yearly plans give access to all paid apps via a single subscription of 89€/month (or 961€/year).
To achieve this, the plans table can now accept a null value for the app_id. When checking if the plan being applied to the account chargbeee model from the subscription is valid, it will now check if the app_id matches or is null.

For more details, please see the [following PR on trustup.pro ](https://github.com/deegitalbe/www.trustup.pro/pull/69)